### PR TITLE
Re-add DATABASE_URL

### DIFF
--- a/commands
+++ b/commands
@@ -153,12 +153,13 @@ case "$1" in
         IP=$(docker inspect $ID | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
         # Write database connection vars to app's ENV file
         # I know there has to be a more eloquent method of doing this...
+        URL="DATABASE_URL=mysql://admin:$DB_PASSWORD@$IP:3306/db"
         HOST="DB_HOST=$IP"
         USER="DB_USER=admin"
         PASS="DB_PASS=$DB_PASSWORD"
         NAME="DB_NAME=db"
         PORT="DB_PORT=3306"
-        dokku config:set $APP $HOST $USER $PASS $NAME $PORT
+        dokku config:set $APP $URL $HOST $USER $PASS $NAME $PORT
         echo
         echo "-----> $APP linked to $DB_IMAGE database"
     fi


### PR DESCRIPTION
Maybe you can enlighten me on the full context of https://github.com/k2nr/dokku-mysql-plugin/commit/1c179fab6afbc983a851efb6168bb3b504c75442 but Heroku's buildpack depends on `DATABASE_URL` (see: https://github.com/heroku/heroku-buildpack-ruby/blob/fbc7046672abe06bf4774c451f4a029aecf1a12e/lib/language_pack/ruby.rb#L582-L586)

This PR re-adds `DATABASE_URL` but also leaves the other variables you added.

@k2nr thoughts?
